### PR TITLE
Fix: Correct syntax error in playmove.js

### DIFF
--- a/playmove.js
+++ b/playmove.js
@@ -110,16 +110,9 @@ router.post('/', async (req, res) => { // Added async here
     // Player is dead, don't save. Just return the game state (which includes death message).
     console.log(`Player is dead. Game state for ${saveFileName} not saved.`);
     let outputs = dungeon.getOutputs(globals);
-      outputs.mapRefresh = globals.mapRefresh;
-      res.json(JSON.stringify(outputs));
-    })
-    .catch((err) => {
-      console.error('Error saving game state:', err);
-      // Still return response even if save fails
-      let outputs = dungeon.getOutputs(globals);
-      outputs.mapRefresh = globals.mapRefresh;
-      res.json(JSON.stringify(outputs));
-    });
+    outputs.mapRefresh = globals.mapRefresh;
+    res.json(JSON.stringify(outputs));
+    // Removed extraneous .catch() and parenthesis as saveGame is not called here.
 });
 
 module.exports = router;


### PR DESCRIPTION
Removes an extraneous closing parenthesis and a misplaced .catch() block within the logic that handles responses when the player is dead and the game state is not saved. This was causing a SyntaxError.