### PR TITLE
Fix: Correct final syntax error in playmove.js

### DIFF
--- a/playmove.js
+++ b/playmove.js
@@ -112,7 +112,8 @@ router.post('/', async (req, res) => { // Added async here
     let outputs = dungeon.getOutputs(globals);
     outputs.mapRefresh = globals.mapRefresh;
     res.json(JSON.stringify(outputs));
-    // Removed extraneous .catch() and parenthesis as saveGame is not called here.
-});
+  } // This closes the 'else' block
+
+}); // This closes router.post('/', async (req, res) => { ... });
 
 module.exports = router;


### PR DESCRIPTION
Ensures the 'else' block within the save game logic is properly closed before the router.post callback function is closed. This resolves the persistent 'Unexpected token )' syntax error.