### PR TITLE
Refactor frontend JavaScript to remove jQuery dependency

### DIFF
--- a/static/animation.js
+++ b/static/animation.js
@@ -7,7 +7,15 @@ function updategame(output,mapsize,radius,opentab){
 	drawviscreatures(output.creatures,output.stats.position,offset,mapsize,radius);
 	drawplayer(radius*tilesize,radius*tilesize,output.stats.equipment,mapsize,radius);
 	if (output.mapRefresh) {
-		$.post("minimap",{dud:0},function(data,status){
+		fetch("minimap", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/x-www-form-urlencoded"
+			},
+			body: new URLSearchParams({dud:0})
+		})
+		.then(response => response.text())
+		.then(data => {
 			var mapctx = document.getElementById("controls").getContext("2d");
 			mapctx.fillStyle = "#000000";
 			mapctx.fillRect(0,0,180,180);
@@ -30,7 +38,8 @@ function updategame(output,mapsize,radius,opentab){
 					}
 				}
 			}
-		});
+		})
+		.catch(error => console.error("Error:", error));
 	}
 	var ctx = document.getElementById("controls").getContext("2d");
 	ctx.fillStyle = "#000000";
@@ -66,21 +75,21 @@ function updategame(output,mapsize,radius,opentab){
 		for (item=0;item<14;item++){
 			if (typeof output.stats.inventory[item]!='undefined'){
 				var itemtype=output.stats.inventory[item].type;
-				$("#inventory [value="+item+"]").attr("src","getimage?imageof="+itemtype+"&tilesize=32");
+				document.querySelector("#inventory [value='"+item+"']").setAttribute("src","getimage?imageof="+itemtype+"&tilesize=32");
 				newimg = document.getElementById(itemtype);
 				ctx.drawImage(newimg,136+(item%7)*36,378+Math.floor(item/7)*50,36,36);
 			} else {
-				$("#inventory [value="+item+"]").attr("src","getimage?imageof=none&tilesize=32");
+				document.querySelector("#inventory [value='"+item+"']").setAttribute("src","getimage?imageof=none&tilesize=32");
 			}
 		}
 		for (item=0;item<7;item++){
 			if (output.stats.equipment[item]){
 				var itemtype=output.stats.equipment[item].type;
-				$("#equipment [value="+item+"]").attr("src","getimage?imageof="+itemtype+"&tilesize=36");
+				document.querySelector("#equipment [value='"+item+"']").setAttribute("src","getimage?imageof="+itemtype+"&tilesize=36");
 				newimg = document.getElementById(itemtype);
 				ctx.drawImage(newimg,136+item*36,326,36,36);
 			} else {
-				$("#equipment [value="+item+"]").attr("src","getimage?imageof=none&tilesize=36");
+				document.querySelector("#equipment [value='"+item+"']").setAttribute("src","getimage?imageof=none&tilesize=36");
 			}
 		}
 		if (typeof output.stats.onground!='undefined') for (item=0;item<7;item++){
@@ -91,11 +100,11 @@ function updategame(output,mapsize,radius,opentab){
 				} else if (itemtype=="weapon"||itemtype=="armour"||itemtype=="shield"||itemtype=="helmet") {
 					itemtype=output.stats.onground[item].name;
 				}
-				$("#ground [value="+item+"]").attr("src","getimage?imageof="+itemtype+"&tilesize=32");
+				document.querySelector("#ground [value='"+item+"']").setAttribute("src","getimage?imageof="+itemtype+"&tilesize=32");
 				newimg = document.getElementById(itemtype);
 				ctx.drawImage(newimg,136+item*36,472,36,36);
 			} else {
-				$("#ground [value="+item+"]").attr("src","getimage?imageof=none&tilesize=32");
+				document.querySelector("#ground [value='"+item+"']").setAttribute("src","getimage?imageof=none&tilesize=32");
 			}
 		}
 	}
@@ -103,15 +112,16 @@ function updategame(output,mapsize,radius,opentab){
 	for (spell=0;spell<7;spell++){
 		if (typeof output.stats.repetoire[spell]!='undefined'){
 			var spelltype=output.stats.repetoire[spell].school;
-			$("#spells [value="+spell+"]").attr("src","getimage?imageof="+spelltype+"&tilesize=32");
+			document.querySelector("#spells [value='"+spell+"']").setAttribute("src","getimage?imageof="+spelltype+"&tilesize=32");
 		} else {
-			$("#spells [value="+spell+"]").attr("src","getimage?imageof=none&tilesize=32");
+			document.querySelector("#spells [value='"+spell+"']").setAttribute("src","getimage?imageof=none&tilesize=32");
 		}
 	}
 	
+	const movelogElement = document.getElementById("movelog");
 	for (move in output.movelog){
-		$("#movelog").prepend(output.movelog[move]+"<br/>");
-		$("#movelog").scrollTop(0);
+		movelogElement.insertAdjacentHTML('afterbegin', output.movelog[move]+"<br/>");
+		movelogElement.scrollTop = 0;
 	}
 	return output;
 }
@@ -471,8 +481,8 @@ function animationcycle(output,lastoutput,ctx,mapsize,radius,opentab){
 			},80);
 		} else {
 			timer=0;
-			$("#menu").css("display","block");
-			$("#map").css("display","none");
+			document.getElementById("menu").style.display = "block";
+			document.getElementById("map").style.display = "none";
 		}
 		return output;
 	}

--- a/static/gwarl.js
+++ b/static/gwarl.js
@@ -1,7 +1,7 @@
 var waiting=false;
 var showanimations=true;
 var interrupt=false;
-$(document).ready(function(){
+document.addEventListener('DOMContentLoaded', function(){
 	var mapsize=612;
 	var radius=8;
 	var tilesize=Math.floor(mapsize/(2*radius+1));
@@ -19,14 +19,23 @@ $(document).ready(function(){
 			ctx.font = "12px";
 			ctx.fillStyle = "#C0C0C0";
 			ctx.fillText("Waiting for server",0,10);
-			$.post("playmove",lastinput,function(data,status){
+			fetch("playmove", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/x-www-form-urlencoded"
+				},
+				body: new URLSearchParams(lastinput)
+			})
+			.then(response => response.text())
+			.then(data => {
 				var output=parsedata(data);
 				lastoutputs=refreshgame(output,outputs,lastinput);
-			});
+			})
+			.catch(error => console.error("Error:", error));
 		}
 		return outputs;
 	}
-	$(this).keydown(function(e){
+	document.addEventListener('keydown', function(e){
 		e.preventDefault();
 		if (!waiting){
 			var keycode = e.which;        
@@ -99,14 +108,23 @@ $(document).ready(function(){
 				ctx.font = "12px";
 				ctx.fillStyle = "#C0C0C0";
 				ctx.fillText("Waiting for server",0,10);
-				$.post("playmove",move,function(data,status){
+				fetch("playmove", {
+					method: "POST",
+					headers: {
+						"Content-Type": "application/x-www-form-urlencoded"
+					},
+					body: new URLSearchParams(move)
+				})
+				.then(response => response.text())
+				.then(data => {
 					var output=parsedata(data);
 					lastoutputs=refreshgame(output,lastoutputs,move);
-				});
+				})
+				.catch(error => console.error("Error:", error));
 			}
 		}
 	});
-	$("#map").click(function(event){
+	document.getElementById("map").addEventListener('click', function(event){
 		event.preventDefault();
 		var mousex=event.clientX-this.offsetLeft;
 		var mousey=event.clientY-this.offsetTop;
@@ -126,19 +144,37 @@ $(document).ready(function(){
 			ctx.fillStyle = "#C0C0C0";
 			ctx.fillText("Waiting for server",0,10);
 			if (event.shiftKey){
-				$.post("playmove",{command:"cast",modifier:JSON.stringify(input)},function(data,status){
+				fetch("playmove", {
+					method: "POST",
+					headers: {
+						"Content-Type": "application/x-www-form-urlencoded"
+					},
+					body: new URLSearchParams({command:"cast",modifier:JSON.stringify(input)})
+				})
+				.then(response => response.text())
+				.then(data => {
 					var outputs=parsedata(data);
 					lastoutputs=refreshgame(outputs,lastoutputs);
-				});
+				})
+				.catch(error => console.error("Error:", error));
 			} else {
-				$.post("playmove",{command:"moveto",modifier:JSON.stringify(input)},function(data,status){
+				fetch("playmove", {
+					method: "POST",
+					headers: {
+						"Content-Type": "application/x-www-form-urlencoded"
+					},
+					body: new URLSearchParams({command:"moveto",modifier:JSON.stringify(input)})
+				})
+				.then(response => response.text())
+				.then(data => {
 					var outputs=parsedata(data);
 					lastoutputs=refreshgame(outputs,lastoutputs,{command:"moveto",modifier:JSON.stringify(input)});
-				});
+				})
+				.catch(error => console.error("Error:", error));
 			}
 		}
 	});
-	$("#map").mousemove(function(event){
+	document.getElementById("map").addEventListener('mousemove', function(event){
 		var mousex=event.clientX-this.offsetLeft;
 		var mousey=event.clientY-this.offsetTop;
 		var focus=getsquarecontents(
@@ -170,24 +206,33 @@ $(document).ready(function(){
 		ctx.font = "24px";
 		ctx.fillText(thingtype,144,208);
 	});
-	$("#newlevel").click(function(){
-		$("#menu").css("display","none");
-		$("#map").css("display","block");
+	document.getElementById("newlevel").addEventListener('click', function(){
+		document.getElementById("menu").style.display = "none";
+		document.getElementById("map").style.display = "block";
 		if (!waiting) {
 			waiting=true;
 			var ctx = document.getElementById("map").getContext("2d");
 			ctx.font = "12px";
 			ctx.fillStyle = "#C0C0C0";
 			ctx.fillText("Waiting for server",0,10);
-			$.post("levelgen",{dud:0},function(data,status){
+			fetch("levelgen", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/x-www-form-urlencoded"
+				},
+				body: new URLSearchParams({dud:0})
+			})
+			.then(response => response.text())
+			.then(data => {
 				//$("#player").attr("src","getplayerimg?tilesize=108");
 				var outputs=parsedata(data);
 				lastoutputs=refreshgame(outputs,lastoutputs);
-				$("#movelog").html("Player has entered the dungeon</br>");
-			});
+				document.getElementById("movelog").innerHTML = "Player has entered the dungeon</br>";
+			})
+			.catch(error => console.error("Error:", error));
 		}
 	});
-	$("#controls").mousemove(function(event){
+	document.getElementById("controls").addEventListener('mousemove', function(event){
 		event.preventDefault();
 		var mousex=event.clientX-this.offsetLeft;
 		var mousey=event.clientY-this.offsetTop;
@@ -238,9 +283,9 @@ $(document).ready(function(){
 		ctx.font = "24px";
 		ctx.fillText(strrep,144,208);
 	});
-	$("#controls").click(function(event){
+	document.getElementById("controls").addEventListener('click', function(event){
 		event.preventDefault();
-		$("#debug").html("clicked ");
+		document.getElementById("debug").innerHTML = "clicked ";
 		var mousex=event.clientX-this.offsetLeft;
 		var mousey=event.clientY-this.offsetTop;
 		var fback;
@@ -256,10 +301,19 @@ $(document).ready(function(){
 					ctx.fillStyle = "#C0C0C0";
 					ctx.fillText("Waiting for server",0,10);
 					var move = {command:"moveto",modifier:JSON.stringify(input)};
-					$.post("playmove",move,function(data,status){						
+					fetch("playmove", {
+						method: "POST",
+						headers: {
+							"Content-Type": "application/x-www-form-urlencoded"
+						},
+						body: new URLSearchParams(move)
+					})
+					.then(response => response.text())
+					.then(data => {
 						var outputs=parsedata(data);
 						lastoutputs=refreshgame(outputs,lastoutputs,move);
-					});
+					})
+					.catch(error => console.error("Error:", error));
 				}
 				fback="minimap";
 			} else {
@@ -278,10 +332,19 @@ $(document).ready(function(){
 							ctx.fillStyle = "#C0C0C0";
 							ctx.fillText("Waiting for server",0,10);
 							var move = {command:"moveto",modifier:JSON.stringify(input)};
-							$.post("playmove",move,function(data,status){
+							fetch("playmove", {
+								method: "POST",
+								headers: {
+									"Content-Type": "application/x-www-form-urlencoded"
+								},
+								body: new URLSearchParams(move)
+							})
+							.then(response => response.text())
+							.then(data => {
 								var outputs=parsedata(data);
 								lastoutputs=refreshgame(outputs,lastoutputs,move);
-							});
+							})
+							.catch(error => console.error("Error:", error));
 						}
 					} else if (mousex<284){
 						fback="fight";
@@ -293,11 +356,19 @@ $(document).ready(function(){
 							ctx.font = "12px";
 							ctx.fillStyle = "#C0C0C0";
 							ctx.fillText("Waiting for server",0,10);
-							$.post("playmove",{command:"moveto",modifier:JSON.stringify(input)},function(data,status){
-								
+							fetch("playmove", {
+								method: "POST",
+								headers: {
+									"Content-Type": "application/x-www-form-urlencoded"
+								},
+								body: new URLSearchParams({command:"moveto",modifier:JSON.stringify(input)})
+							})
+							.then(response => response.text())
+							.then(data => {
 								var outputs=parsedata(data);
 								lastoutputs=refreshgame(outputs,lastoutputs);
-							});
+							})
+							.catch(error => console.error("Error:", error));
 						} else {
 							lastoutputs.movelog=["No creature in view"];
 							updategame(lastoutputs,mapsize,radius,opentab);
@@ -311,11 +382,19 @@ $(document).ready(function(){
 							ctx.font = "12px";
 							ctx.fillStyle = "#C0C0C0";
 							ctx.fillText("Waiting for server",0,10);
-							$.post("playmove",{command:input,modifier:100},function(data,status){
-								
+							fetch("playmove", {
+								method: "POST",
+								headers: {
+									"Content-Type": "application/x-www-form-urlencoded"
+								},
+								body: new URLSearchParams({command:input,modifier:100})
+							})
+							.then(response => response.text())
+							.then(data => {
 								var outputs=parsedata(data);
 								lastoutputs=refreshgame(outputs,lastoutputs);
-							});
+							})
+							.catch(error => console.error("Error:", error));
 						}
 					} else {
 						fback="cast";
@@ -327,11 +406,19 @@ $(document).ready(function(){
 							ctx.font = "12px";
 							ctx.fillStyle = "#C0C0C0";
 							ctx.fillText("Waiting for server",0,10);
-							$.post("playmove",{command:"cast",modifier:JSON.stringify(input)},function(data,status){
-								
+							fetch("playmove", {
+								method: "POST",
+								headers: {
+									"Content-Type": "application/x-www-form-urlencoded"
+								},
+								body: new URLSearchParams({command:"cast",modifier:JSON.stringify(input)})
+							})
+							.then(response => response.text())
+							.then(data => {
 								var outputs=parsedata(data);
 								lastoutputs=refreshgame(outputs,lastoutputs);
-							});
+							})
+							.catch(error => console.error("Error:", error));
 						} else {
 							lastoutputs.movelog=[];
 							updategame(lastoutputs,mapsize,radius);
@@ -393,10 +480,19 @@ $(document).ready(function(){
 							ctx.font = "12px";
 							ctx.fillStyle = "#C0C0C0";
 							ctx.fillText("Waiting for server",0,10);
-							$.post("playmove",{command:input,modifier:itemchoice},function(data,status){
+							fetch("playmove", {
+								method: "POST",
+								headers: {
+									"Content-Type": "application/x-www-form-urlencoded"
+								},
+								body: new URLSearchParams({command:input,modifier:itemchoice})
+							})
+							.then(response => response.text())
+							.then(data => {
 								var outputs=parsedata(data);
 								lastoutputs=refreshgame(outputs,lastoutputs);
-							});	
+							})
+							.catch(error => console.error("Error:", error));
 						}
 					}
 				} else if (opentab=="options"){
@@ -408,21 +504,29 @@ $(document).ready(function(){
 							ctx.font = "12px";
 							ctx.fillStyle = "#C0C0C0";
 							ctx.fillText("Waiting for server",0,10);
-							$.post("playmove",{command:input,modifier:false},function(data,status){
-								
+							fetch("playmove", {
+								method: "POST",
+								headers: {
+									"Content-Type": "application/x-www-form-urlencoded"
+								},
+								body: new URLSearchParams({command:input,modifier:false})
+							})
+							.then(response => response.text())
+							.then(data => {
 								var outputs=parsedata(data);
 								lastoutputs=refreshgame(outputs,lastoutputs);
-							});
+							})
+							.catch(error => console.error("Error:", error));
 						}
 					}
 				};
 			}
 		}
-		$("#debug").html(fback);
+		document.getElementById("debug").innerHTML = fback;
 	});
 	
 	//actual code to be executed upon page loading
-	$("#loadingscreen").css("display","none");
-	$("#menu").css("display","block");
+	document.getElementById("loadingscreen").style.display = "none";
+	document.getElementById("menu").style.display = "block";
 	drawUIskin(opentab);
 });

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -3,7 +3,6 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
 <script src="util.js"></script>
 <script src="draw.js"></script>
 <script src="animation.js"></script>


### PR DESCRIPTION
Replaced all jQuery usage in /static JavaScript files with plain JavaScript equivalents:

- AJAX ($.post) calls refactored to use the fetch API.
- DOM manipulations (selectors, attr, css, html, prepend, scrollTop) refactored to use standard DOM methods (querySelector, getAttribute, setAttribute, style, innerHTML, insertAdjacentHTML, scrollTop).
- Event handling ($(document).ready, .click, .keydown, .mousemove) refactored to use addEventListener.

Removed jQuery script include from index.ejs.