### PR TITLE
Refactor: Abstract frontend API calls with playmove function

### DIFF
--- a/static/animation.js
+++ b/static/animation.js
@@ -7,7 +7,7 @@ function updategame(output,mapsize,radius,opentab){
 	drawviscreatures(output.creatures,output.stats.position,offset,mapsize,radius);
 	drawplayer(radius*tilesize,radius*tilesize,output.stats.equipment,mapsize,radius);
 	if (output.mapRefresh) {
-		postData("/api", {command:"info", modifier:"minimap"}).then(data => {
+		playmove("info", "minimap").then(data => {
 			if (data === null) return;
 			var mapctx = document.getElementById("controls").getContext("2d");
 			mapctx.fillStyle = "#000000";

--- a/static/gwarl.js
+++ b/static/gwarl.js
@@ -18,7 +18,7 @@ document.addEventListener('DOMContentLoaded', function(){
 			ctx.font = "12px";
 			ctx.fillStyle = "#C0C0C0";
 			ctx.fillText("Waiting for server",0,10);
-			postData("/api", lastinput).then(data => {
+			playmove(lastinput.command, lastinput.modifier).then(data => {
 				if (data === null) return; // Error handled in postData
 				var output=parsedata(data);
 				lastoutputs=refreshgame(output,outputs,lastinput);
@@ -101,7 +101,7 @@ document.addEventListener('DOMContentLoaded', function(){
 				ctx.font = "12px";
 				ctx.fillStyle = "#C0C0C0";
 				ctx.fillText("Waiting for server",0,10);
-				postData("/api", move).then(data => {
+				playmove(move.command, move.modifier).then(data => {
 					if (data === null) return;
 					var output=parsedata(data);
 					lastoutputs=refreshgame(output,lastoutputs,move);
@@ -130,13 +130,13 @@ document.addEventListener('DOMContentLoaded', function(){
 			ctx.fillStyle = "#C0C0C0";
 			ctx.fillText("Waiting for server",0,10);
 			if (event.shiftKey){
-				postData("/api", {command:"cast",modifier:input}).then(data => {
+				playmove("cast", input).then(data => {
 					if (data === null) return;
 					var outputs=parsedata(data);
 					lastoutputs=refreshgame(outputs,lastoutputs);
 				}).catch(error => console.error('Fetch error:', error));
 			} else {
-				postData("/api", {command:"moveto",modifier:input}).then(data => {
+				playmove("moveto", input).then(data => {
 					if (data === null) return;
 					var outputs=parsedata(data);
 					lastoutputs=refreshgame(outputs,lastoutputs,{command:"moveto",modifier:input});
@@ -188,7 +188,7 @@ document.addEventListener('DOMContentLoaded', function(){
 			ctx.font = "12px";
 			ctx.fillStyle = "#C0C0C0";
 			ctx.fillText("Waiting for server",0,10);
-			postData("/api", {command:"start", modifier:"Player"}).then(data => { 
+			playmove("start", "Player").then(data => {
 				if (data === null) return;
 				var outputs=parsedata(data);
 				lastoutputs=refreshgame(outputs,lastoutputs);
@@ -265,7 +265,7 @@ document.addEventListener('DOMContentLoaded', function(){
 					ctx.fillStyle = "#C0C0C0";
 					ctx.fillText("Waiting for server",0,10);
 					var move = {command:"moveto",modifier:input};
-					postData("/api", move).then(data => {
+					playmove(move.command, move.modifier).then(data => {
 						if (data === null) return;
 						var outputs=parsedata(data);
 						lastoutputs=refreshgame(outputs,lastoutputs,move);
@@ -288,7 +288,7 @@ document.addEventListener('DOMContentLoaded', function(){
 							ctx.fillStyle = "#C0C0C0";
 							ctx.fillText("Waiting for server",0,10);
 							var move = {command:"moveto",modifier:input};
-							postData("/api", move).then(data => {
+							playmove(move.command, move.modifier).then(data => {
 								if (data === null) return;
 								var outputs=parsedata(data);
 								lastoutputs=refreshgame(outputs,lastoutputs,move);
@@ -304,7 +304,7 @@ document.addEventListener('DOMContentLoaded', function(){
 							ctx.font = "12px";
 							ctx.fillStyle = "#C0C0C0";
 							ctx.fillText("Waiting for server",0,10);
-							postData("/api", {command:"moveto",modifier:input}).then(data => {
+							playmove("moveto", input).then(data => {
 								if (data === null) return;
 								var outputs=parsedata(data);
 								lastoutputs=refreshgame(outputs,lastoutputs);
@@ -322,7 +322,7 @@ document.addEventListener('DOMContentLoaded', function(){
 							ctx.font = "12px";
 							ctx.fillStyle = "#C0C0C0";
 							ctx.fillText("Waiting for server",0,10);
-							postData("/api", {command:input,modifier:100}).then(data => {
+							playmove(input, 100).then(data => {
 								if (data === null) return;
 								var outputs=parsedata(data);
 								lastoutputs=refreshgame(outputs,lastoutputs);
@@ -338,7 +338,7 @@ document.addEventListener('DOMContentLoaded', function(){
 							ctx.font = "12px";
 							ctx.fillStyle = "#C0C0C0";
 							ctx.fillText("Waiting for server",0,10);
-							postData("/api", {command:"cast",modifier:input}).then(data => {
+							playmove("cast", input).then(data => {
 								if (data === null) return;
 								var outputs=parsedata(data);
 								lastoutputs=refreshgame(outputs,lastoutputs);
@@ -404,7 +404,7 @@ document.addEventListener('DOMContentLoaded', function(){
 							ctx.font = "12px";
 							ctx.fillStyle = "#C0C0C0";
 							ctx.fillText("Waiting for server",0,10);
-							postData("/api", {command:input,modifier:itemchoice}).then(data => {
+							playmove(input, itemchoice).then(data => {
 								if (data === null) return;
 								var outputs=parsedata(data);
 								lastoutputs=refreshgame(outputs,lastoutputs);
@@ -420,7 +420,7 @@ document.addEventListener('DOMContentLoaded', function(){
 							ctx.font = "12px";
 							ctx.fillStyle = "#C0C0C0";
 							ctx.fillText("Waiting for server",0,10);
-							postData("/api", {command:input,modifier:false}).then(data => {
+							playmove(input, false).then(data => {
 								if (data === null) return;
 								var outputs=parsedata(data);
 								lastoutputs=refreshgame(outputs,lastoutputs);

--- a/static/util.js
+++ b/static/util.js
@@ -127,7 +127,7 @@ function parsedata(thisdata){
 	return outputs;
 }
 function playmove(command,modifier){
-	
+	return postData("/api", { command: command, modifier: modifier });
 }
 function drawUIskin(opentab){ 
 	var ctx = document.getElementById("controls").getContext("2d");


### PR DESCRIPTION
I implemented a new `playmove` function in `util.js` to encapsulate the logic for making API calls to the backend.

I updated `gwarl.js` and `animation.js` to use `playmove` instead of directly calling `postData` for all frontend-backend communication.